### PR TITLE
Add heart buttons to now-playing view

### DIFF
--- a/blackbird/src/ui/group.rs
+++ b/blackbird/src/ui/group.rs
@@ -76,6 +76,7 @@ pub fn ui<'a>(
                         TextStyle::Body.resolve(ui.style()),
                         ui_util::HeartPlacement::Space,
                         group.starred,
+                        false,
                     );
 
                     if heart_response.clicked() {

--- a/blackbird/src/ui/mod.rs
+++ b/blackbird/src/ui/mod.rs
@@ -240,6 +240,19 @@ fn playing_track_info(
 
                         ui.vertical(|ui| {
                             ui.horizontal(|ui| {
+                                // Add heart for track
+                                let (heart_response, _) = util::draw_heart(
+                                    ui,
+                                    TextStyle::Body.resolve(ui.style()),
+                                    util::HeartPlacement::Space,
+                                    tdd.starred,
+                                    true,
+                                );
+                                if heart_response.clicked() {
+                                    track_heart_clicked = true;
+                                }
+                                ui.add_space(4.0);
+
                                 if let Some(artist) = tdd
                                     .track_artist
                                     .as_ref()
@@ -261,19 +274,21 @@ fn playing_track_info(
                                     )
                                     .selectable(false),
                                 );
-
-                                // Add heart for track
+                            });
+                            ui.horizontal(|ui| {
+                                // Add heart for album
                                 let (heart_response, _) = util::draw_heart(
                                     ui,
                                     TextStyle::Body.resolve(ui.style()),
                                     util::HeartPlacement::Space,
-                                    tdd.starred,
+                                    album_starred,
+                                    true,
                                 );
                                 if heart_response.clicked() {
-                                    track_heart_clicked = true;
+                                    album_heart_clicked = true;
                                 }
-                            });
-                            ui.horizontal(|ui| {
+                                ui.add_space(4.0);
+
                                 ui.add(
                                     Label::new(
                                         RichText::new(&tdd.album_name).color(config.style.album()),
@@ -288,17 +303,6 @@ fn playing_track_info(
                                     )
                                     .selectable(false),
                                 );
-
-                                // Add heart for album
-                                let (heart_response, _) = util::draw_heart(
-                                    ui,
-                                    TextStyle::Body.resolve(ui.style()),
-                                    util::HeartPlacement::Space,
-                                    album_starred,
-                                );
-                                if heart_response.clicked() {
-                                    album_heart_clicked = true;
-                                }
                             });
                         });
                     });
@@ -415,38 +419,34 @@ fn playing_track_info(
         }
     });
 
-    if track_clicked && let Some(track_id) = track_id {
-        *track_to_scroll_to = Some(track_id);
+    if track_clicked && let Some(ref track_id) = track_id {
+        *track_to_scroll_to = Some(track_id.clone());
     }
 
-    if track_heart_clicked {
-        if let Some(ref track_id) = track_id {
-            let starred = logic
-                .get_state()
-                .read()
-                .unwrap()
-                .library
-                .track_map
-                .get(track_id)
-                .map(|track| track.starred)
-                .unwrap_or(false);
-            logic.set_track_starred(track_id, !starred);
-        }
+    if track_heart_clicked && let Some(ref track_id) = track_id {
+        let starred = logic
+            .get_state()
+            .read()
+            .unwrap()
+            .library
+            .track_map
+            .get(track_id)
+            .map(|track| track.starred)
+            .unwrap_or(false);
+        logic.set_track_starred(track_id, !starred);
     }
 
-    if album_heart_clicked {
-        if let Some(ref album_id) = album_id {
-            let starred = logic
-                .get_state()
-                .read()
-                .unwrap()
-                .library
-                .albums
-                .get(album_id)
-                .map(|album| album.starred)
-                .unwrap_or(false);
-            logic.set_album_starred(album_id, !starred);
-        }
+    if album_heart_clicked && let Some(ref album_id) = album_id {
+        let starred = logic
+            .get_state()
+            .read()
+            .unwrap()
+            .library
+            .albums
+            .get(album_id)
+            .map(|album| album.starred)
+            .unwrap_or(false);
+        logic.set_album_starred(album_id, !starred);
     }
 }
 

--- a/blackbird/src/ui/track.rs
+++ b/blackbird/src/ui/track.rs
@@ -50,6 +50,7 @@ pub fn ui(
             right_aligned: true,
         },
         track.starred,
+        false,
     );
     right_x -= heart_size;
     if heart_response.clicked() {

--- a/blackbird/src/ui/util.rs
+++ b/blackbird/src/ui/util.rs
@@ -21,6 +21,7 @@ pub fn draw_heart(
     font: egui::FontId,
     placement: HeartPlacement,
     active: bool,
+    show_outline_when_inactive: bool,
 ) -> (egui::Response, f32) {
     let size = ui.fonts(|f| f.row_height(&font));
 
@@ -35,11 +36,11 @@ pub fn draw_heart(
     let hovered = response.hovered();
 
     // If:
-    // - unstarred, unhovered: invisible
+    // - unstarred, unhovered: invisible (or white outline if show_outline_when_inactive)
     // - unstarred, hovered: unfilled, red
     // - starred, unhovered: filled, red
     // - starred, hovered: unfilled, white
-    let visible = active || hovered;
+    let visible = active || hovered || show_outline_when_inactive;
     let filled = active && !hovered;
     let is_red = (!active && hovered) || (active && !hovered);
 


### PR DESCRIPTION
Add clickable heart icons for both track and album in the now-playing view, matching the functionality already present in the playlist/library view.

- Added heart icon next to track title that toggles track starred status
- Added heart icon next to album info that toggles album starred status
- Hearts follow the same visual behavior as in playlist view (hover effects, filled when starred, etc.)