### PR TITLE
Fix letter display conflict resolution

### DIFF
--- a/blackbird-state/src/lib.rs
+++ b/blackbird-state/src/lib.rs
@@ -28,7 +28,7 @@ pub use artist::ArtistId;
 /// - Case level off
 ///
 /// This means "E" and "È" will compare as equal, and "Track 2" will sort before "Track 10".
-pub fn create_collator() -> icu_collator::Collator {
+pub fn create_collator() -> icu_collator::CollatorBorrowed<'static> {
     let mut collator_preferences = icu_collator::CollatorPreferences::default();
     collator_preferences.numeric_ordering =
         Some(icu_collator::preferences::CollationNumericOrdering::True);

--- a/blackbird/src/ui/mod.rs
+++ b/blackbird/src/ui/mod.rs
@@ -878,7 +878,7 @@ fn compute_alphabet_scroll_positions(logic: &mut bc::Logic, ui_state: &mut UiSta
         return;
     }
 
-    let collator = bc::create_collator();
+    let collator = bc::blackbird_state::create_collator();
 
     // Group information: stores all character variants and their counts for each collator-equal group
     // along with the position where this group starts
@@ -924,13 +924,13 @@ fn compute_alphabet_scroll_positions(logic: &mut bc::Logic, ui_state: &mut UiSta
     let total_rows = current_row;
 
     // For each group, select the variant with the highest count and convert position to fraction
-    let mut positions_with_fractions: Vec<(char, f32, usize)> = letter_groups
+    let positions_with_fractions: Vec<(char, f32, usize)> = letter_groups
         .into_iter()
         .map(|group| {
             let (&best_char, &count) = group
                 .variants
                 .iter()
-                .max_by_key(|(_char, &count)| count)
+                .max_by_key(|&(_char, count)| count)
                 .unwrap();
             let fraction = group.position as f32 / total_rows as f32;
             (best_char, fraction, count)


### PR DESCRIPTION
Previously, the letter display would simply skip letters that were too close together (first-come-first-served). Now the clustering logic:

1. Collects album counts for each letter during precomputation
2. Clusters letters within 1.5% of viewport height
3. Selects the letter with the most albums from each cluster
4. Moves filtering from render-time to precomputation step

This ensures the most representative letters are displayed when there are conflicts, improving navigation for dense library sections.