### PR TITLE
Fix track shuffle algorithm seed issue

### DIFF
--- a/blackbird-core/src/app_state.rs
+++ b/blackbird-core/src/app_state.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Library, TrackDisplayDetails, queue::QueueState};
 
-#[derive(Default)]
 pub struct AppState {
     pub library: Library,
 
@@ -20,6 +19,22 @@ pub struct AppState {
     pub scrobble_state: ScrobbleState,
 
     pub error: Option<AppStateError>,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self {
+            library: Library::default(),
+            current_track_and_position: None,
+            started_loading_track: None,
+            last_requested_track_for_ui_scroll: None,
+            playback_mode: PlaybackMode::default(),
+            queue: QueueState::new(),
+            volume: 0.0,
+            scrobble_state: ScrobbleState::default(),
+            error: None,
+        }
+    }
 }
 
 /// Tracks scrobbling state for the currently playing track.

--- a/blackbird-core/src/queue.rs
+++ b/blackbird-core/src/queue.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 
 // Queue-specific state stored under AppState
-#[derive(Default)]
 pub struct QueueState {
     pub shuffle_seed: u64,
     pub audio_cache: HashMap<TrackId, Vec<u8>>,
@@ -29,6 +28,13 @@ pub struct QueueState {
     pub group_shuffle_seed: u64,
     pub next_track_appended: Option<TrackId>,
 }
+
+impl Default for QueueState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl QueueState {
     pub fn new() -> Self {
         let now = SystemTime::now()
@@ -38,7 +44,13 @@ impl QueueState {
         QueueState {
             shuffle_seed: seed,
             group_shuffle_seed: next_seed(seed),
-            ..Default::default()
+            audio_cache: HashMap::new(),
+            pending_audio_requests: HashMap::new(),
+            request_counter: 0,
+            current_target: None,
+            current_target_request_id: None,
+            pending_skip_after_error: false,
+            next_track_appended: None,
         }
     }
 }


### PR DESCRIPTION
Previously, the shuffle seed was always initialized to 0 because AppState::default() used the derived Default implementation for QueueState, which set all u64 fields to 0. This caused the shuffle order to be identical across all launches.

Now QueueState::new() is properly called via a custom Default implementation for both QueueState and AppState, ensuring a fresh time-based seed is generated on each launch.

Changes:
- Remove #[derive(Default)] from QueueState and AppState
- Implement custom Default for QueueState that calls new()
- Implement custom Default for AppState that calls QueueState::new()
- Explicitly initialize all QueueState fields in new()