### PR TITLE
Add ReplayGain support for volume normalization

### DIFF
--- a/blackbird-client-shared/src/config.rs
+++ b/blackbird-client-shared/src/config.rs
@@ -120,11 +120,18 @@ pub struct Playback {
     /// Whether ReplayGain volume adjustments should be applied during playback.
     #[serde(default = "default_true")]
     pub apply_replaygain: bool,
+    /// Preamp added on top of the ReplayGain-computed gain, in dB. Useful for
+    /// compensating for ReplayGain's ~−18 LUFS reference level, which can feel
+    /// quiet next to unprocessed modern masters. Clipping protection still
+    /// applies, so tracks with high peaks may be attenuated below this value.
+    #[serde(default)]
+    pub replaygain_preamp_db: f32,
 }
 impl Default for Playback {
     fn default() -> Self {
         Self {
             apply_replaygain: true,
+            replaygain_preamp_db: 0.0,
         }
     }
 }

--- a/blackbird-client-shared/src/config.rs
+++ b/blackbird-client-shared/src/config.rs
@@ -104,10 +104,29 @@ pub struct Config {
     /// Layout configuration for the library and player UI.
     #[serde(default)]
     pub layout: Layout,
+    /// Playback-related settings shared across clients.
+    #[serde(default)]
+    pub playback: Playback,
 }
 
 fn default_true() -> bool {
     true
+}
+
+/// Playback-related settings shared across clients.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct Playback {
+    /// Whether ReplayGain volume adjustments should be applied during playback.
+    #[serde(default = "default_true")]
+    pub apply_replaygain: bool,
+}
+impl Default for Playback {
+    fn default() -> Self {
+        Self {
+            apply_replaygain: true,
+        }
+    }
 }
 
 /// Last playback state, persisted across sessions.

--- a/blackbird-core/src/app_state.rs
+++ b/blackbird-core/src/app_state.rs
@@ -126,6 +126,8 @@ pub struct AppState {
     pub volume: f32,
     /// Whether to apply ReplayGain adjustments to tracks loaded for playback.
     pub apply_replaygain: bool,
+    /// Preamp added on top of the ReplayGain-computed gain, in dB.
+    pub replaygain_preamp_db: f32,
 
     pub scrobble_state: ScrobbleState,
 
@@ -145,6 +147,7 @@ impl Default for AppState {
             queue: QueueState::new(),
             volume: 0.0,
             apply_replaygain: false,
+            replaygain_preamp_db: 0.0,
             scrobble_state: ScrobbleState::default(),
             error: None,
         }

--- a/blackbird-core/src/app_state.rs
+++ b/blackbird-core/src/app_state.rs
@@ -124,6 +124,8 @@ pub struct AppState {
     pub sort_order: SortOrder,
     pub queue: QueueState,
     pub volume: f32,
+    /// Whether to apply ReplayGain adjustments to tracks loaded for playback.
+    pub apply_replaygain: bool,
 
     pub scrobble_state: ScrobbleState,
 
@@ -142,6 +144,7 @@ impl Default for AppState {
             sort_order: SortOrder::default(),
             queue: QueueState::new(),
             volume: 0.0,
+            apply_replaygain: false,
             scrobble_state: ScrobbleState::default(),
             error: None,
         }

--- a/blackbird-core/src/lib.rs
+++ b/blackbird-core/src/lib.rs
@@ -788,16 +788,24 @@ impl Logic {
         self.send_to_playback(LogicToPlaybackMessage::SetVolume(volume));
     }
 
-    /// Returns whether ReplayGain is currently being applied at load time.
+    /// Returns whether ReplayGain is currently being applied.
     pub fn get_apply_replaygain(&self) -> bool {
         self.read_state().apply_replaygain
     }
 
-    /// Enables or disables ReplayGain application. Changes take effect for
-    /// subsequently loaded tracks; the currently playing track keeps the gain
-    /// it was loaded with.
+    /// Enables or disables ReplayGain application. Takes effect immediately
+    /// for every queued source, including the one playing right now. No-op
+    /// if the value is unchanged.
     pub fn set_apply_replaygain(&self, enabled: bool) {
-        self.write_state().apply_replaygain = enabled;
+        let changed = {
+            let mut st = self.write_state();
+            let changed = st.apply_replaygain != enabled;
+            st.apply_replaygain = enabled;
+            changed
+        };
+        if changed {
+            self.send_to_playback(LogicToPlaybackMessage::SetApplyReplayGain(enabled));
+        }
     }
 
     /// Get cover art IDs for albums surrounding (and including) the next track in the queue.
@@ -1050,6 +1058,7 @@ impl Logic {
 
                     let req_id;
                     let volume;
+                    let apply_replaygain;
                     {
                         let mut st = state.write().unwrap();
                         let sort_order = st.sort_order;
@@ -1076,12 +1085,13 @@ impl Logic {
 
                         req_id = st.queue.request_counter;
                         volume = st.volume;
+                        apply_replaygain = st.apply_replaygain;
                     }
 
                     // Server connection succeeded — start the playback thread
                     // (opens the audio device). The main thread picks it up in
                     // `update()`.
-                    let pt = PlaybackThread::new(volume, playback_event_tx);
+                    let pt = PlaybackThread::new(volume, apply_replaygain, playback_event_tx);
                     let playback_tx = pt.send_handle();
                     *playback_thread_slot.lock().unwrap() = Some(pt);
 

--- a/blackbird-core/src/lib.rs
+++ b/blackbird-core/src/lib.rs
@@ -14,7 +14,7 @@ mod render;
 pub use render::VisibleGroupSet;
 
 mod playback_thread;
-use playback_thread::{LogicToPlaybackMessage, PlaybackThread, TrackLoadMode};
+use playback_thread::{LogicToPlaybackMessage, PlaybackThread, TrackLoadMode, TrackPlayback};
 pub use playback_thread::{PlaybackState, PlaybackToLogicMessage, PlaybackToLogicRx};
 
 mod tokio_thread;
@@ -422,11 +422,11 @@ impl Logic {
 
                 if !already_appended && let Some(data) = audio_data {
                     tracing::debug!("Appending next track for gapless playback: {}", next_id.0);
-                    self.send_to_playback(LogicToPlaybackMessage::AppendNextTrack(
-                        next_id.clone(),
+                    self.send_to_playback(LogicToPlaybackMessage::AppendNextTrack(TrackPlayback {
+                        track_id: next_id.clone(),
                         data,
                         gain,
-                    ));
+                    }));
                     self.write_state().queue.next_track_appended = Some(next_id);
                 }
             }

--- a/blackbird-core/src/lib.rs
+++ b/blackbird-core/src/lib.rs
@@ -191,6 +191,7 @@ pub struct LogicArgs {
     pub password: String,
     pub transcode: bool,
     pub volume: f32,
+    pub apply_replaygain: bool,
     pub sort_order: SortOrder,
     pub playback_mode: PlaybackMode,
     pub last_playback: Option<(TrackId, Duration)>,
@@ -208,6 +209,7 @@ impl Logic {
             password,
             transcode,
             volume,
+            apply_replaygain,
             sort_order,
             playback_mode,
             last_playback,
@@ -219,6 +221,7 @@ impl Logic {
     ) -> Self {
         let state = Arc::new(RwLock::new(AppState {
             volume,
+            apply_replaygain,
             sort_order,
             playback_mode,
             ..AppState::default()
@@ -408,11 +411,12 @@ impl Logic {
 
             // Don't append if we're in the middle of changing tracks
             if !pending_track_change && let Some(next_id) = self.compute_next_track_id() {
-                let (already_appended, audio_data) = {
+                let (already_appended, audio_data, gain) = {
                     let st = self.read_state();
                     (
                         st.queue.next_track_appended.as_ref() == Some(&next_id),
                         st.queue.audio_cache.get(&next_id).cloned(),
+                        queue::gain_for_track(&st, &next_id),
                     )
                 };
 
@@ -421,6 +425,7 @@ impl Logic {
                     self.send_to_playback(LogicToPlaybackMessage::AppendNextTrack(
                         next_id.clone(),
                         data,
+                        gain,
                     ));
                     self.write_state().queue.next_track_appended = Some(next_id);
                 }
@@ -781,6 +786,18 @@ impl Logic {
     pub fn set_volume(&self, volume: f32) {
         self.write_state().volume = volume;
         self.send_to_playback(LogicToPlaybackMessage::SetVolume(volume));
+    }
+
+    /// Returns whether ReplayGain is currently being applied at load time.
+    pub fn get_apply_replaygain(&self) -> bool {
+        self.read_state().apply_replaygain
+    }
+
+    /// Enables or disables ReplayGain application. Changes take effect for
+    /// subsequently loaded tracks; the currently playing track keeps the gain
+    /// it was loaded with.
+    pub fn set_apply_replaygain(&self, enabled: bool) {
+        self.write_state().apply_replaygain = enabled;
     }
 
     /// Get cover art IDs for albums surrounding (and including) the next track in the queue.

--- a/blackbird-core/src/lib.rs
+++ b/blackbird-core/src/lib.rs
@@ -192,6 +192,7 @@ pub struct LogicArgs {
     pub transcode: bool,
     pub volume: f32,
     pub apply_replaygain: bool,
+    pub replaygain_preamp_db: f32,
     pub sort_order: SortOrder,
     pub playback_mode: PlaybackMode,
     pub last_playback: Option<(TrackId, Duration)>,
@@ -210,6 +211,7 @@ impl Logic {
             transcode,
             volume,
             apply_replaygain,
+            replaygain_preamp_db,
             sort_order,
             playback_mode,
             last_playback,
@@ -222,6 +224,7 @@ impl Logic {
         let state = Arc::new(RwLock::new(AppState {
             volume,
             apply_replaygain,
+            replaygain_preamp_db,
             sort_order,
             playback_mode,
             ..AppState::default()
@@ -411,12 +414,12 @@ impl Logic {
 
             // Don't append if we're in the middle of changing tracks
             if !pending_track_change && let Some(next_id) = self.compute_next_track_id() {
-                let (already_appended, audio_data, gain) = {
+                let (already_appended, audio_data, replaygain) = {
                     let st = self.read_state();
                     (
                         st.queue.next_track_appended.as_ref() == Some(&next_id),
                         st.queue.audio_cache.get(&next_id).cloned(),
-                        queue::gain_for_track(&st, &next_id),
+                        queue::replaygain_for_track(&st, &next_id),
                     )
                 };
 
@@ -425,7 +428,7 @@ impl Logic {
                     self.send_to_playback(LogicToPlaybackMessage::AppendNextTrack(TrackPlayback {
                         track_id: next_id.clone(),
                         data,
-                        gain,
+                        replaygain,
                     }));
                     self.write_state().queue.next_track_appended = Some(next_id);
                 }
@@ -808,6 +811,25 @@ impl Logic {
         }
     }
 
+    /// Returns the current ReplayGain preamp, in dB.
+    pub fn get_replaygain_preamp_db(&self) -> f32 {
+        self.read_state().replaygain_preamp_db
+    }
+
+    /// Sets the ReplayGain preamp in dB. Takes effect immediately for every
+    /// queued source. No-op if the value is unchanged.
+    pub fn set_replaygain_preamp_db(&self, preamp_db: f32) {
+        let changed = {
+            let mut st = self.write_state();
+            let changed = st.replaygain_preamp_db != preamp_db;
+            st.replaygain_preamp_db = preamp_db;
+            changed
+        };
+        if changed {
+            self.send_to_playback(LogicToPlaybackMessage::SetReplayGainPreamp(preamp_db));
+        }
+    }
+
     /// Get cover art IDs for albums surrounding (and including) the next track in the queue.
     /// Returns an empty vector if there is no next track or if the library is not populated.
     pub fn get_next_track_surrounding_cover_art_ids(&self) -> Vec<CoverArtId> {
@@ -1059,6 +1081,7 @@ impl Logic {
                     let req_id;
                     let volume;
                     let apply_replaygain;
+                    let replaygain_preamp_db;
                     {
                         let mut st = state.write().unwrap();
                         let sort_order = st.sort_order;
@@ -1086,12 +1109,18 @@ impl Logic {
                         req_id = st.queue.request_counter;
                         volume = st.volume;
                         apply_replaygain = st.apply_replaygain;
+                        replaygain_preamp_db = st.replaygain_preamp_db;
                     }
 
                     // Server connection succeeded — start the playback thread
                     // (opens the audio device). The main thread picks it up in
                     // `update()`.
-                    let pt = PlaybackThread::new(volume, apply_replaygain, playback_event_tx);
+                    let pt = PlaybackThread::new(
+                        volume,
+                        apply_replaygain,
+                        replaygain_preamp_db,
+                        playback_event_tx,
+                    );
                     let playback_tx = pt.send_handle();
                     *playback_thread_slot.lock().unwrap() = Some(pt);
 

--- a/blackbird-core/src/library.rs
+++ b/blackbird-core/src/library.rs
@@ -467,6 +467,7 @@ mod tests {
                     album_id: Some(album_id.clone()),
                     starred: false,
                     play_count: None,
+                    replay_gain: None,
                 },
             );
             albums.entry(album_id.clone()).or_insert_with(|| Album {

--- a/blackbird-core/src/playback_thread.rs
+++ b/blackbird-core/src/playback_thread.rs
@@ -9,7 +9,7 @@ use std::collections::VecDeque;
 #[cfg(feature = "audio")]
 use std::sync::Arc;
 #[cfg(feature = "audio")]
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU32};
 
 pub struct PlaybackThread {
     /// Wrapped in `Option` so that `Drop` can close the channel before joining
@@ -37,24 +37,76 @@ pub enum TrackLoadMode {
     Paused(Duration),
 }
 
+/// The ReplayGain-derived coefficients for a single track. The playback
+/// thread combines `factor` with a live preamp and clamps the product to
+/// `inv_peak` to prevent clipping.
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+pub struct ReplayGainTrackInfo {
+    /// Base linear factor computed from the track's `trackGain`/`albumGain`
+    /// plus `baseGain`. Does not include the user-configurable preamp.
+    pub factor: f32,
+    /// `1 / peak` — the maximum linear multiplier that keeps the loudest
+    /// sample at or below 1.0. `f32::INFINITY` if no peak is available.
+    pub inv_peak: f32,
+}
+
 /// A track's decoded-audio payload as sent to the playback thread.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct TrackPlayback {
     pub track_id: TrackId,
     pub data: Vec<u8>,
-    /// Optional linear amplification factor (e.g. from ReplayGain) applied on
-    /// top of the decoded samples.
-    pub gain: Option<f32>,
+    /// ReplayGain coefficients. `None` means the track has no metadata and
+    /// will be played back untouched (no preamp or clipping-clamp applied).
+    pub replaygain: Option<ReplayGainTrackInfo>,
+}
+
+/// Shared state read per sample by every queued [`RuntimeReplayGain`]
+/// source. Owned by the playback thread and updated via
+/// [`LogicToPlaybackMessage::SetApplyReplayGain`] / [`SetReplayGainPreamp`].
+#[cfg(feature = "audio")]
+#[derive(Clone)]
+struct ReplayGainControl {
+    enabled: Arc<AtomicBool>,
+    /// Preamp as a linear factor (i.e. `10^(preamp_db / 20)`) stored as
+    /// `f32::to_bits` so the atomic load is lock-free.
+    preamp_linear_bits: Arc<AtomicU32>,
+}
+
+#[cfg(feature = "audio")]
+impl ReplayGainControl {
+    fn new(enabled: bool, preamp_db: f32) -> Self {
+        Self {
+            enabled: Arc::new(AtomicBool::new(enabled)),
+            preamp_linear_bits: Arc::new(AtomicU32::new(db_to_linear(preamp_db).to_bits())),
+        }
+    }
+
+    fn set_enabled(&self, enabled: bool) {
+        self.enabled
+            .store(enabled, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn set_preamp_db(&self, preamp_db: f32) {
+        self.preamp_linear_bits.store(
+            db_to_linear(preamp_db).to_bits(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
+}
+
+#[cfg(feature = "audio")]
+fn db_to_linear(db: f32) -> f32 {
+    10f32.powf(db / 20.0)
 }
 
 #[cfg(feature = "audio")]
 impl TrackPlayback {
-    /// Decodes the audio payload and appends it to `sink`, wrapping the
-    /// decoded source in a [`RuntimeReplayGain`] that reads its enabled flag
-    /// from `apply_replaygain` per sample. This means toggling the shared
-    /// flag affects every source currently queued on the sink — including
-    /// the one playing right now — without any master-volume trickery.
+    /// Decodes the audio payload and appends it to `sink`. When the track
+    /// has ReplayGain metadata, the decoded source is wrapped in a
+    /// [`RuntimeReplayGain`] that reads `control` per sample, so toggling
+    /// the setting or moving the preamp takes effect mid-track.
     ///
     /// Returns the `TrackId` back for use in subsequent bookkeeping, or
     /// alongside the decode error on failure so the caller can report
@@ -62,7 +114,7 @@ impl TrackPlayback {
     fn decode_and_append(
         self,
         sink: &rodio::Sink,
-        apply_replaygain: Arc<AtomicBool>,
+        control: ReplayGainControl,
     ) -> Result<TrackId, (TrackId, rodio::decoder::DecoderError)> {
         let decoder = rodio::decoder::DecoderBuilder::new()
             .with_byte_len(self.data.len() as u64)
@@ -72,35 +124,28 @@ impl TrackPlayback {
             Ok(d) => d,
             Err(e) => return Err((self.track_id, e)),
         };
-        sink.append(RuntimeReplayGain::new(
-            decoder,
-            self.gain.unwrap_or(1.0),
-            apply_replaygain,
-        ));
+        match self.replaygain {
+            Some(info) => sink.append(RuntimeReplayGain {
+                input: decoder,
+                info,
+                control,
+            }),
+            None => sink.append(decoder),
+        }
         Ok(self.track_id)
     }
 }
 
-/// A rodio [`Source`](rodio::Source) wrapper that multiplies each sample by
-/// `factor` when `enabled` is true, and passes samples through unchanged
-/// otherwise. The flag is shared via [`Arc`] so that it can be flipped from
-/// outside the audio thread to take effect mid-track.
+/// A rodio [`Source`](rodio::Source) wrapper that applies `info.factor *
+/// preamp` to each sample when enabled, clamped to `info.inv_peak` to avoid
+/// clipping. The enabled flag and preamp value are read per sample from a
+/// shared [`ReplayGainControl`] so they can be updated live from outside the
+/// audio thread.
 #[cfg(feature = "audio")]
 struct RuntimeReplayGain<I> {
     input: I,
-    factor: f32,
-    enabled: Arc<AtomicBool>,
-}
-
-#[cfg(feature = "audio")]
-impl<I> RuntimeReplayGain<I> {
-    fn new(input: I, factor: f32, enabled: Arc<AtomicBool>) -> Self {
-        Self {
-            input,
-            factor,
-            enabled,
-        }
-    }
+    info: ReplayGainTrackInfo,
+    control: ReplayGainControl,
 }
 
 #[cfg(feature = "audio")]
@@ -112,9 +157,12 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
+        use std::sync::atomic::Ordering::Relaxed;
         let sample = self.input.next()?;
-        if self.enabled.load(std::sync::atomic::Ordering::Relaxed) {
-            Some(sample * self.factor)
+        if self.control.enabled.load(Relaxed) {
+            let preamp = f32::from_bits(self.control.preamp_linear_bits.load(Relaxed));
+            let multiplier = (self.info.factor * preamp).min(self.info.inv_peak);
+            Some(sample * multiplier)
         } else {
             Some(sample)
         }
@@ -180,6 +228,9 @@ pub enum LogicToPlaybackMessage {
     /// Enables or disables ReplayGain application for every queued source,
     /// including the one currently playing.
     SetApplyReplayGain(bool),
+    /// Adjusts the ReplayGain preamp (in dB) for every queued source,
+    /// including the one currently playing.
+    SetReplayGainPreamp(f32),
     /// Sent during shutdown to exit the playback loop immediately. Needed
     /// because cloned `PlaybackThreadSendHandle`s in tokio tasks keep the
     /// channel open, so disconnect alone is not reliable.
@@ -218,12 +269,13 @@ impl Drop for PlaybackThread {
 }
 
 impl PlaybackThread {
-    /// Creates a new playback thread with the given volume, ReplayGain toggle,
-    /// and broadcast sender. The broadcast sender is used to send playback
-    /// events back to the logic layer.
+    /// Creates a new playback thread with the given volume, ReplayGain
+    /// settings, and broadcast sender. The broadcast sender is used to send
+    /// playback events back to the logic layer.
     pub fn new(
         volume: f32,
         apply_replaygain: bool,
+        replaygain_preamp_db: f32,
         playback_to_logic_tx: tokio::sync::broadcast::Sender<PlaybackToLogicMessage>,
     ) -> Self {
         let (logic_to_playback_tx, logic_to_playback_rx) =
@@ -235,6 +287,7 @@ impl PlaybackThread {
                 playback_to_logic_tx,
                 volume,
                 apply_replaygain,
+                replaygain_preamp_db,
             );
         });
 
@@ -262,14 +315,16 @@ impl PlaybackThread {
         logic_tx: tokio::sync::broadcast::Sender<PlaybackToLogicMessage>,
         volume: f32,
         apply_replaygain: bool,
+        replaygain_preamp_db: f32,
     ) {
         use LogicToPlaybackMessage as LTPM;
         use PlaybackToLogicMessage as PTLM;
         use rodio::cpal::traits::HostTrait as _;
 
         // Shared with every source appended to the sink so that flipping the
-        // flag takes effect mid-track, not just on the next load.
-        let apply_replaygain = Arc::new(AtomicBool::new(apply_replaygain));
+        // toggle or moving the preamp takes effect mid-track, not just on
+        // the next load.
+        let replaygain = ReplayGainControl::new(apply_replaygain, replaygain_preamp_db);
 
         fn error_callback(err: rodio::cpal::StreamError) {
             tracing::warn!("audio stream error: {err}");
@@ -351,26 +406,25 @@ impl PlaybackThread {
 
                         // Append new track first, then clear old tracks.
                         // This ensures the sink is never completely empty.
-                        let track_id =
-                            match track.decode_and_append(&sink, apply_replaygain.clone()) {
-                                Ok(track_id) => track_id,
-                                Err((track_id, err)) => {
-                                    // Send a dummy track-started to ensure core is aware of what the
-                                    // track was that caused the failure.
-                                    let _ = logic_tx.send(PTLM::TrackStarted(TrackAndPosition {
-                                        track_id: track_id.clone(),
-                                        position: Duration::from_secs(0),
-                                    }));
-                                    update_and_send_state(
-                                        &logic_tx,
-                                        &mut state,
-                                        PlaybackState::Stopped,
-                                    );
-                                    let _ = logic_tx
-                                        .send(PTLM::FailedToPlayTrack(track_id, err.to_string()));
-                                    continue;
-                                }
-                            };
+                        let track_id = match track.decode_and_append(&sink, replaygain.clone()) {
+                            Ok(track_id) => track_id,
+                            Err((track_id, err)) => {
+                                // Send a dummy track-started to ensure core is aware of what the
+                                // track was that caused the failure.
+                                let _ = logic_tx.send(PTLM::TrackStarted(TrackAndPosition {
+                                    track_id: track_id.clone(),
+                                    position: Duration::from_secs(0),
+                                }));
+                                update_and_send_state(
+                                    &logic_tx,
+                                    &mut state,
+                                    PlaybackState::Stopped,
+                                );
+                                let _ = logic_tx
+                                    .send(PTLM::FailedToPlayTrack(track_id, err.to_string()));
+                                continue;
+                            }
+                        };
 
                         // Skip all old tracks (everything except the one we just appended).
                         let tracks_to_skip = queued_tracks.len();
@@ -406,20 +460,19 @@ impl PlaybackThread {
                     }
                     LTPM::AppendNextTrack(track) => {
                         // Append to sink for gapless playback.
-                        let track_id =
-                            match track.decode_and_append(&sink, apply_replaygain.clone()) {
-                                Ok(track_id) => track_id,
-                                Err((track_id, err)) => {
-                                    tracing::warn!(
-                                        "Failed to decode next track {}: {}",
-                                        track_id.0,
-                                        err
-                                    );
-                                    let _ = logic_tx
-                                        .send(PTLM::FailedToPlayTrack(track_id, err.to_string()));
-                                    continue;
-                                }
-                            };
+                        let track_id = match track.decode_and_append(&sink, replaygain.clone()) {
+                            Ok(track_id) => track_id,
+                            Err((track_id, err)) => {
+                                tracing::warn!(
+                                    "Failed to decode next track {}: {}",
+                                    track_id.0,
+                                    err
+                                );
+                                let _ = logic_tx
+                                    .send(PTLM::FailedToPlayTrack(track_id, err.to_string()));
+                                continue;
+                            }
+                        };
                         queued_tracks.push_back(track_id.clone());
                         tracing::debug!(
                             "Appended next track {} (queue length: {})",
@@ -500,7 +553,10 @@ impl PlaybackThread {
                         sink.set_volume(volume * volume);
                     }
                     LTPM::SetApplyReplayGain(enabled) => {
-                        apply_replaygain.store(enabled, std::sync::atomic::Ordering::Relaxed);
+                        replaygain.set_enabled(enabled);
+                    }
+                    LTPM::SetReplayGainPreamp(preamp_db) => {
+                        replaygain.set_preamp_db(preamp_db);
                     }
                     LTPM::Shutdown => return,
                 }
@@ -577,6 +633,7 @@ impl PlaybackThread {
         _logic_tx: tokio::sync::broadcast::Sender<PlaybackToLogicMessage>,
         _volume: f32,
         _apply_replaygain: bool,
+        _replaygain_preamp_db: f32,
     ) {
         unimplemented!(
             "Audio playback is disabled - blackbird-core was built without the 'audio' feature"

--- a/blackbird-core/src/playback_thread.rs
+++ b/blackbird-core/src/playback_thread.rs
@@ -6,6 +6,10 @@ use crate::app_state::TrackAndPosition;
 
 #[cfg(feature = "audio")]
 use std::collections::VecDeque;
+#[cfg(feature = "audio")]
+use std::sync::Arc;
+#[cfg(feature = "audio")]
+use std::sync::atomic::AtomicBool;
 
 pub struct PlaybackThread {
     /// Wrapped in `Option` so that `Drop` can close the channel before joining
@@ -46,16 +50,20 @@ pub struct TrackPlayback {
 
 #[cfg(feature = "audio")]
 impl TrackPlayback {
-    /// Decodes the audio payload and appends it to `sink`, applying `gain` as
-    /// an amplification factor when set. Returns the `TrackId` back for use
-    /// in subsequent bookkeeping on success, or alongside the decode error on
-    /// failure so the caller can report which track failed.
+    /// Decodes the audio payload and appends it to `sink`, wrapping the
+    /// decoded source in a [`RuntimeReplayGain`] that reads its enabled flag
+    /// from `apply_replaygain` per sample. This means toggling the shared
+    /// flag affects every source currently queued on the sink — including
+    /// the one playing right now — without any master-volume trickery.
+    ///
+    /// Returns the `TrackId` back for use in subsequent bookkeeping, or
+    /// alongside the decode error on failure so the caller can report
+    /// which track failed.
     fn decode_and_append(
         self,
         sink: &rodio::Sink,
+        apply_replaygain: Arc<AtomicBool>,
     ) -> Result<TrackId, (TrackId, rodio::decoder::DecoderError)> {
-        use rodio::Source as _;
-
         let decoder = rodio::decoder::DecoderBuilder::new()
             .with_byte_len(self.data.len() as u64)
             .with_data(std::io::Cursor::new(self.data))
@@ -64,11 +72,88 @@ impl TrackPlayback {
             Ok(d) => d,
             Err(e) => return Err((self.track_id, e)),
         };
-        match self.gain {
-            Some(factor) => sink.append(decoder.amplify(factor)),
-            None => sink.append(decoder),
-        }
+        sink.append(RuntimeReplayGain::new(
+            decoder,
+            self.gain.unwrap_or(1.0),
+            apply_replaygain,
+        ));
         Ok(self.track_id)
+    }
+}
+
+/// A rodio [`Source`](rodio::Source) wrapper that multiplies each sample by
+/// `factor` when `enabled` is true, and passes samples through unchanged
+/// otherwise. The flag is shared via [`Arc`] so that it can be flipped from
+/// outside the audio thread to take effect mid-track.
+#[cfg(feature = "audio")]
+struct RuntimeReplayGain<I> {
+    input: I,
+    factor: f32,
+    enabled: Arc<AtomicBool>,
+}
+
+#[cfg(feature = "audio")]
+impl<I> RuntimeReplayGain<I> {
+    fn new(input: I, factor: f32, enabled: Arc<AtomicBool>) -> Self {
+        Self {
+            input,
+            factor,
+            enabled,
+        }
+    }
+}
+
+#[cfg(feature = "audio")]
+impl<I> Iterator for RuntimeReplayGain<I>
+where
+    I: rodio::Source,
+{
+    type Item = I::Item;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let sample = self.input.next()?;
+        if self.enabled.load(std::sync::atomic::Ordering::Relaxed) {
+            Some(sample * self.factor)
+        } else {
+            Some(sample)
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.input.size_hint()
+    }
+}
+
+#[cfg(feature = "audio")]
+impl<I> rodio::Source for RuntimeReplayGain<I>
+where
+    I: rodio::Source,
+{
+    #[inline]
+    fn current_span_len(&self) -> Option<usize> {
+        self.input.current_span_len()
+    }
+
+    #[inline]
+    fn channels(&self) -> rodio::ChannelCount {
+        self.input.channels()
+    }
+
+    #[inline]
+    fn sample_rate(&self) -> rodio::SampleRate {
+        self.input.sample_rate()
+    }
+
+    #[inline]
+    fn total_duration(&self) -> Option<Duration> {
+        self.input.total_duration()
+    }
+
+    #[inline]
+    fn try_seek(&mut self, pos: Duration) -> Result<(), rodio::source::SeekError> {
+        self.input.try_seek(pos)
     }
 }
 
@@ -92,6 +177,9 @@ pub enum LogicToPlaybackMessage {
     /// final position is always applied.
     SeekImmediate(Duration),
     SetVolume(f32),
+    /// Enables or disables ReplayGain application for every queued source,
+    /// including the one currently playing.
+    SetApplyReplayGain(bool),
     /// Sent during shutdown to exit the playback loop immediately. Needed
     /// because cloned `PlaybackThreadSendHandle`s in tokio tasks keep the
     /// channel open, so disconnect alone is not reliable.
@@ -130,17 +218,24 @@ impl Drop for PlaybackThread {
 }
 
 impl PlaybackThread {
-    /// Creates a new playback thread with the given volume and broadcast sender.
-    /// The broadcast sender is used to send playback events back to the logic layer.
+    /// Creates a new playback thread with the given volume, ReplayGain toggle,
+    /// and broadcast sender. The broadcast sender is used to send playback
+    /// events back to the logic layer.
     pub fn new(
         volume: f32,
+        apply_replaygain: bool,
         playback_to_logic_tx: tokio::sync::broadcast::Sender<PlaybackToLogicMessage>,
     ) -> Self {
         let (logic_to_playback_tx, logic_to_playback_rx) =
             std::sync::mpsc::channel::<LogicToPlaybackMessage>();
 
         let playback_thread_handle = std::thread::spawn(move || {
-            Self::run(logic_to_playback_rx, playback_to_logic_tx, volume);
+            Self::run(
+                logic_to_playback_rx,
+                playback_to_logic_tx,
+                volume,
+                apply_replaygain,
+            );
         });
 
         Self {
@@ -166,10 +261,15 @@ impl PlaybackThread {
         playback_rx: std::sync::mpsc::Receiver<LogicToPlaybackMessage>,
         logic_tx: tokio::sync::broadcast::Sender<PlaybackToLogicMessage>,
         volume: f32,
+        apply_replaygain: bool,
     ) {
         use LogicToPlaybackMessage as LTPM;
         use PlaybackToLogicMessage as PTLM;
         use rodio::cpal::traits::HostTrait as _;
+
+        // Shared with every source appended to the sink so that flipping the
+        // flag takes effect mid-track, not just on the next load.
+        let apply_replaygain = Arc::new(AtomicBool::new(apply_replaygain));
 
         fn error_callback(err: rodio::cpal::StreamError) {
             tracing::warn!("audio stream error: {err}");
@@ -251,25 +351,26 @@ impl PlaybackThread {
 
                         // Append new track first, then clear old tracks.
                         // This ensures the sink is never completely empty.
-                        let track_id = match track.decode_and_append(&sink) {
-                            Ok(track_id) => track_id,
-                            Err((track_id, err)) => {
-                                // Send a dummy track-started to ensure core is aware of what the
-                                // track was that caused the failure.
-                                let _ = logic_tx.send(PTLM::TrackStarted(TrackAndPosition {
-                                    track_id: track_id.clone(),
-                                    position: Duration::from_secs(0),
-                                }));
-                                update_and_send_state(
-                                    &logic_tx,
-                                    &mut state,
-                                    PlaybackState::Stopped,
-                                );
-                                let _ = logic_tx
-                                    .send(PTLM::FailedToPlayTrack(track_id, err.to_string()));
-                                continue;
-                            }
-                        };
+                        let track_id =
+                            match track.decode_and_append(&sink, apply_replaygain.clone()) {
+                                Ok(track_id) => track_id,
+                                Err((track_id, err)) => {
+                                    // Send a dummy track-started to ensure core is aware of what the
+                                    // track was that caused the failure.
+                                    let _ = logic_tx.send(PTLM::TrackStarted(TrackAndPosition {
+                                        track_id: track_id.clone(),
+                                        position: Duration::from_secs(0),
+                                    }));
+                                    update_and_send_state(
+                                        &logic_tx,
+                                        &mut state,
+                                        PlaybackState::Stopped,
+                                    );
+                                    let _ = logic_tx
+                                        .send(PTLM::FailedToPlayTrack(track_id, err.to_string()));
+                                    continue;
+                                }
+                            };
 
                         // Skip all old tracks (everything except the one we just appended).
                         let tracks_to_skip = queued_tracks.len();
@@ -305,19 +406,20 @@ impl PlaybackThread {
                     }
                     LTPM::AppendNextTrack(track) => {
                         // Append to sink for gapless playback.
-                        let track_id = match track.decode_and_append(&sink) {
-                            Ok(track_id) => track_id,
-                            Err((track_id, err)) => {
-                                tracing::warn!(
-                                    "Failed to decode next track {}: {}",
-                                    track_id.0,
-                                    err
-                                );
-                                let _ = logic_tx
-                                    .send(PTLM::FailedToPlayTrack(track_id, err.to_string()));
-                                continue;
-                            }
-                        };
+                        let track_id =
+                            match track.decode_and_append(&sink, apply_replaygain.clone()) {
+                                Ok(track_id) => track_id,
+                                Err((track_id, err)) => {
+                                    tracing::warn!(
+                                        "Failed to decode next track {}: {}",
+                                        track_id.0,
+                                        err
+                                    );
+                                    let _ = logic_tx
+                                        .send(PTLM::FailedToPlayTrack(track_id, err.to_string()));
+                                    continue;
+                                }
+                            };
                         queued_tracks.push_back(track_id.clone());
                         tracing::debug!(
                             "Appended next track {} (queue length: {})",
@@ -397,6 +499,9 @@ impl PlaybackThread {
                     LTPM::SetVolume(volume) => {
                         sink.set_volume(volume * volume);
                     }
+                    LTPM::SetApplyReplayGain(enabled) => {
+                        apply_replaygain.store(enabled, std::sync::atomic::Ordering::Relaxed);
+                    }
                     LTPM::Shutdown => return,
                 }
             }
@@ -471,6 +576,7 @@ impl PlaybackThread {
         _playback_rx: std::sync::mpsc::Receiver<LogicToPlaybackMessage>,
         _logic_tx: tokio::sync::broadcast::Sender<PlaybackToLogicMessage>,
         _volume: f32,
+        _apply_replaygain: bool,
     ) {
         unimplemented!(
             "Audio playback is disabled - blackbird-core was built without the 'audio' feature"

--- a/blackbird-core/src/playback_thread.rs
+++ b/blackbird-core/src/playback_thread.rs
@@ -33,16 +33,27 @@ pub enum TrackLoadMode {
     Paused(Duration),
 }
 
+/// A track's decoded-audio payload as sent to the playback thread.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct TrackPlayback {
+    pub track_id: TrackId,
+    pub data: Vec<u8>,
+    /// Optional linear amplification factor (e.g. from ReplayGain) applied on
+    /// top of the decoded samples.
+    pub gain: Option<f32>,
+}
+
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub enum LogicToPlaybackMessage {
     /// Load a track with the specified mode (play or paused at position).
-    /// `gain` is an optional linear amplification factor (e.g. from ReplayGain)
-    /// applied on top of the decoded samples.
-    LoadTrack(TrackId, Vec<u8>, TrackLoadMode, Option<f32>),
-    /// Append a track to the gapless queue. `gain` has the same meaning as in
-    /// [`LogicToPlaybackMessage::LoadTrack`].
-    AppendNextTrack(TrackId, Vec<u8>, Option<f32>),
+    LoadTrack {
+        track: TrackPlayback,
+        mode: TrackLoadMode,
+    },
+    /// Append a track to the gapless queue.
+    AppendNextTrack(TrackPlayback),
     ClearQueuedNextTracks,
     TogglePlayback,
     Play,
@@ -200,7 +211,15 @@ impl PlaybackThread {
                     Err(std::sync::mpsc::TryRecvError::Disconnected) => return,
                 };
                 match msg {
-                    LTPM::LoadTrack(track_id, data, mode, gain) => {
+                    LTPM::LoadTrack {
+                        track:
+                            TrackPlayback {
+                                track_id,
+                                data,
+                                gain,
+                            },
+                        mode,
+                    } => {
                         let decoder = rodio::decoder::DecoderBuilder::new()
                             .with_byte_len(data.len() as u64)
                             .with_data(std::io::Cursor::new(data))
@@ -275,7 +294,11 @@ impl PlaybackThread {
                         };
                         update_and_send_state(&logic_tx, &mut state, new_state);
                     }
-                    LTPM::AppendNextTrack(track_id, data, gain) => {
+                    LTPM::AppendNextTrack(TrackPlayback {
+                        track_id,
+                        data,
+                        gain,
+                    }) => {
                         let decoder = rodio::decoder::DecoderBuilder::new()
                             .with_byte_len(data.len() as u64)
                             .with_data(std::io::Cursor::new(data))

--- a/blackbird-core/src/playback_thread.rs
+++ b/blackbird-core/src/playback_thread.rs
@@ -37,8 +37,12 @@ pub enum TrackLoadMode {
 #[allow(dead_code)]
 pub enum LogicToPlaybackMessage {
     /// Load a track with the specified mode (play or paused at position).
-    LoadTrack(TrackId, Vec<u8>, TrackLoadMode),
-    AppendNextTrack(TrackId, Vec<u8>),
+    /// `gain` is an optional linear amplification factor (e.g. from ReplayGain)
+    /// applied on top of the decoded samples.
+    LoadTrack(TrackId, Vec<u8>, TrackLoadMode, Option<f32>),
+    /// Append a track to the gapless queue. `gain` has the same meaning as in
+    /// [`LogicToPlaybackMessage::LoadTrack`].
+    AppendNextTrack(TrackId, Vec<u8>, Option<f32>),
     ClearQueuedNextTracks,
     TogglePlayback,
     Play,
@@ -126,6 +130,7 @@ impl PlaybackThread {
     ) {
         use LogicToPlaybackMessage as LTPM;
         use PlaybackToLogicMessage as PTLM;
+        use rodio::Source as _;
         use rodio::cpal::traits::HostTrait as _;
 
         fn error_callback(err: rodio::cpal::StreamError) {
@@ -195,7 +200,7 @@ impl PlaybackThread {
                     Err(std::sync::mpsc::TryRecvError::Disconnected) => return,
                 };
                 match msg {
-                    LTPM::LoadTrack(track_id, data, mode) => {
+                    LTPM::LoadTrack(track_id, data, mode, gain) => {
                         let decoder = rodio::decoder::DecoderBuilder::new()
                             .with_byte_len(data.len() as u64)
                             .with_data(std::io::Cursor::new(data))
@@ -233,7 +238,10 @@ impl PlaybackThread {
 
                         // Append new track first, then clear old tracks.
                         // This ensures the sink is never completely empty.
-                        sink.append(decoder);
+                        match gain {
+                            Some(factor) => sink.append(decoder.amplify(factor)),
+                            None => sink.append(decoder),
+                        }
 
                         // Skip all old tracks (everything except the one we just appended).
                         let tracks_to_skip = queued_tracks.len();
@@ -267,7 +275,7 @@ impl PlaybackThread {
                         };
                         update_and_send_state(&logic_tx, &mut state, new_state);
                     }
-                    LTPM::AppendNextTrack(track_id, data) => {
+                    LTPM::AppendNextTrack(track_id, data, gain) => {
                         let decoder = rodio::decoder::DecoderBuilder::new()
                             .with_byte_len(data.len() as u64)
                             .with_data(std::io::Cursor::new(data))
@@ -287,8 +295,11 @@ impl PlaybackThread {
                             }
                         };
 
-                        // Append to sink for gapless playback
-                        sink.append(decoder);
+                        // Append to sink for gapless playback.
+                        match gain {
+                            Some(factor) => sink.append(decoder.amplify(factor)),
+                            None => sink.append(decoder),
+                        }
                         queued_tracks.push_back(track_id.clone());
                         tracing::debug!(
                             "Appended next track {} (queue length: {})",

--- a/blackbird-core/src/playback_thread.rs
+++ b/blackbird-core/src/playback_thread.rs
@@ -44,6 +44,34 @@ pub struct TrackPlayback {
     pub gain: Option<f32>,
 }
 
+#[cfg(feature = "audio")]
+impl TrackPlayback {
+    /// Decodes the audio payload and appends it to `sink`, applying `gain` as
+    /// an amplification factor when set. Returns the `TrackId` back for use
+    /// in subsequent bookkeeping on success, or alongside the decode error on
+    /// failure so the caller can report which track failed.
+    fn decode_and_append(
+        self,
+        sink: &rodio::Sink,
+    ) -> Result<TrackId, (TrackId, rodio::decoder::DecoderError)> {
+        use rodio::Source as _;
+
+        let decoder = rodio::decoder::DecoderBuilder::new()
+            .with_byte_len(self.data.len() as u64)
+            .with_data(std::io::Cursor::new(self.data))
+            .build();
+        let decoder = match decoder {
+            Ok(d) => d,
+            Err(e) => return Err((self.track_id, e)),
+        };
+        match self.gain {
+            Some(factor) => sink.append(decoder.amplify(factor)),
+            None => sink.append(decoder),
+        }
+        Ok(self.track_id)
+    }
+}
+
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub enum LogicToPlaybackMessage {
@@ -141,7 +169,6 @@ impl PlaybackThread {
     ) {
         use LogicToPlaybackMessage as LTPM;
         use PlaybackToLogicMessage as PTLM;
-        use rodio::Source as _;
         use rodio::cpal::traits::HostTrait as _;
 
         fn error_callback(err: rodio::cpal::StreamError) {
@@ -211,23 +238,22 @@ impl PlaybackThread {
                     Err(std::sync::mpsc::TryRecvError::Disconnected) => return,
                 };
                 match msg {
-                    LTPM::LoadTrack {
-                        track:
-                            TrackPlayback {
-                                track_id,
-                                data,
-                                gain,
-                            },
-                        mode,
-                    } => {
-                        let decoder = rodio::decoder::DecoderBuilder::new()
-                            .with_byte_len(data.len() as u64)
-                            .with_data(std::io::Cursor::new(data))
-                            .build();
+                    LTPM::LoadTrack { track, mode } => {
+                        // For paused loads, pause the sink *before* appending so that
+                        // playback does not start automatically.
+                        let paused_position = match &mode {
+                            TrackLoadMode::Play => None,
+                            TrackLoadMode::Paused(pos) => {
+                                sink.pause();
+                                Some(*pos)
+                            }
+                        };
 
-                        let decoder = match decoder {
-                            Ok(decoder) => decoder,
-                            Err(err) => {
+                        // Append new track first, then clear old tracks.
+                        // This ensures the sink is never completely empty.
+                        let track_id = match track.decode_and_append(&sink) {
+                            Ok(track_id) => track_id,
+                            Err((track_id, err)) => {
                                 // Send a dummy track-started to ensure core is aware of what the
                                 // track was that caused the failure.
                                 let _ = logic_tx.send(PTLM::TrackStarted(TrackAndPosition {
@@ -244,23 +270,6 @@ impl PlaybackThread {
                                 continue;
                             }
                         };
-
-                        // For paused loads, pause the sink *before* appending so that
-                        // playback does not start automatically.
-                        let paused_position = match &mode {
-                            TrackLoadMode::Play => None,
-                            TrackLoadMode::Paused(pos) => {
-                                sink.pause();
-                                Some(*pos)
-                            }
-                        };
-
-                        // Append new track first, then clear old tracks.
-                        // This ensures the sink is never completely empty.
-                        match gain {
-                            Some(factor) => sink.append(decoder.amplify(factor)),
-                            None => sink.append(decoder),
-                        }
 
                         // Skip all old tracks (everything except the one we just appended).
                         let tracks_to_skip = queued_tracks.len();
@@ -294,19 +303,11 @@ impl PlaybackThread {
                         };
                         update_and_send_state(&logic_tx, &mut state, new_state);
                     }
-                    LTPM::AppendNextTrack(TrackPlayback {
-                        track_id,
-                        data,
-                        gain,
-                    }) => {
-                        let decoder = rodio::decoder::DecoderBuilder::new()
-                            .with_byte_len(data.len() as u64)
-                            .with_data(std::io::Cursor::new(data))
-                            .build();
-
-                        let decoder = match decoder {
-                            Ok(decoder) => decoder,
-                            Err(err) => {
+                    LTPM::AppendNextTrack(track) => {
+                        // Append to sink for gapless playback.
+                        let track_id = match track.decode_and_append(&sink) {
+                            Ok(track_id) => track_id,
+                            Err((track_id, err)) => {
                                 tracing::warn!(
                                     "Failed to decode next track {}: {}",
                                     track_id.0,
@@ -317,12 +318,6 @@ impl PlaybackThread {
                                 continue;
                             }
                         };
-
-                        // Append to sink for gapless playback.
-                        match gain {
-                            Some(factor) => sink.append(decoder.amplify(factor)),
-                            None => sink.append(decoder),
-                        }
                         queued_tracks.push_back(track_id.clone());
                         tracing::debug!(
                             "Appended next track {} (queue length: {})",

--- a/blackbird-core/src/queue.rs
+++ b/blackbird-core/src/queue.rs
@@ -12,31 +12,42 @@ use crate::{
     AppState, Logic, PlaybackMode, TrackLoadMode,
     app_state::AppStateError,
     library::Library,
-    playback_thread::{LogicToPlaybackMessage, PlaybackThreadSendHandle, TrackPlayback},
+    playback_thread::{
+        LogicToPlaybackMessage, PlaybackThreadSendHandle, ReplayGainTrackInfo, TrackPlayback,
+    },
 };
 
 /// Convenience that reads the track's ReplayGain metadata from the library
-/// and computes the linear factor. Returns `None` if the track is unknown or
-/// has no usable gain data.
+/// and computes the per-track factor/ceiling pair. Returns `None` if the
+/// track is unknown or has no usable gain data.
 ///
 /// The returned factor is unconditional — whether it is actually applied is
-/// decided inside the playback thread via the shared atomic toggle, so that
+/// decided inside the playback thread via a shared atomic toggle, so that
 /// flipping the setting affects the currently playing source.
-pub(crate) fn gain_for_track(state: &AppState, track_id: &TrackId) -> Option<f32> {
+pub(crate) fn replaygain_for_track(
+    state: &AppState,
+    track_id: &TrackId,
+) -> Option<ReplayGainTrackInfo> {
     let track = state.library.track_map.get(track_id)?;
-    compute_replaygain_factor(track.replay_gain.as_ref())
+    compute_replaygain_info(track.replay_gain.as_ref())
 }
 
-/// Computes the linear amplification factor described by `replay_gain`.
+/// Computes the ReplayGain factor and peak-clipping ceiling described by
+/// `replay_gain`.
 ///
 /// Returns `None` if no metadata is present or no gain value can be
 /// determined. Prefers album gain over track gain (matching the default of
 /// foobar2000, MPD, and similar players) so that intra-album loudness
 /// relationships are preserved. `baseGain` (if present) is added to the
 /// chosen gain, and `fallbackGain` is used if neither track nor album gain is
-/// available. The resulting linear factor is clamped so that
-/// `factor * peak <= 1.0`, preventing digital clipping.
-pub(crate) fn compute_replaygain_factor(replay_gain: Option<&ReplayGain>) -> Option<f32> {
+/// available.
+///
+/// The peak-clipping clamp is *not* applied here — it is returned alongside
+/// the factor so the playback thread can recompute the effective gain when
+/// the live preamp changes.
+pub(crate) fn compute_replaygain_info(
+    replay_gain: Option<&ReplayGain>,
+) -> Option<ReplayGainTrackInfo> {
     let rg = replay_gain?;
 
     let (gain_db, peak) = match (rg.album_gain, rg.track_gain) {
@@ -47,14 +58,12 @@ pub(crate) fn compute_replaygain_factor(replay_gain: Option<&ReplayGain>) -> Opt
 
     let total_db = gain_db + rg.base_gain.unwrap_or(0.0);
     let factor = 10f32.powf(total_db / 20.0);
-
-    // Prevent clipping: scale down so the loudest sample stays at or below 1.0.
-    let clipping_ceiling = peak
+    let inv_peak = peak
         .filter(|p| *p > 0.0)
         .map(|p| 1.0 / p)
         .unwrap_or(f32::INFINITY);
 
-    Some(factor.min(clipping_ceiling))
+    Some(ReplayGainTrackInfo { factor, inv_peak })
 }
 
 /// How a loaded track should be handled after streaming.
@@ -188,11 +197,11 @@ impl Logic {
         let cached = {
             let st = self.read_state();
             st.queue.audio_cache.get(track_id).cloned().map(|data| {
-                let gain = gain_for_track(&st, track_id);
+                let replaygain = replaygain_for_track(&st, track_id);
                 TrackPlayback {
                     track_id: track_id.clone(),
                     data,
-                    gain,
+                    replaygain,
                 }
             })
         };
@@ -380,12 +389,12 @@ pub(crate) fn handle_load_response(
 ) {
     match response {
         Ok(data) => {
-            let (is_current_target, gain) = {
+            let (is_current_target, replaygain) = {
                 let mut st = state.write().unwrap();
                 st.queue.audio_cache.insert(track_id.clone(), data.clone());
                 let is_current = st.queue.current_target.as_ref() == Some(&track_id);
-                let gain = gain_for_track(&st, &track_id);
-                (is_current, gain)
+                let replaygain = replaygain_for_track(&st, &track_id);
+                (is_current, replaygain)
             };
 
             match behavior {
@@ -399,7 +408,7 @@ pub(crate) fn handle_load_response(
                         track: TrackPlayback {
                             track_id: track_id.clone(),
                             data,
-                            gain,
+                            replaygain,
                         },
                         mode: TrackLoadMode::Play,
                     });
@@ -414,7 +423,7 @@ pub(crate) fn handle_load_response(
                         track: TrackPlayback {
                             track_id: track_id.clone(),
                             data,
-                            gain,
+                            replaygain,
                         },
                         mode: TrackLoadMode::Paused(position),
                     });
@@ -997,7 +1006,7 @@ mod tests {
 
     #[test]
     fn replaygain_missing_metadata_returns_none() {
-        assert!(compute_replaygain_factor(None).is_none());
+        assert!(compute_replaygain_info(None).is_none());
     }
 
     #[test]
@@ -1007,9 +1016,10 @@ mod tests {
             album_gain: Some(-3.0),
             ..Default::default()
         };
-        let factor = compute_replaygain_factor(Some(&rg)).unwrap();
+        let info = compute_replaygain_info(Some(&rg)).unwrap();
         // -3 dB = 10^(-0.15) ≈ 0.708.
-        assert!(approx_eq(factor, 0.708));
+        assert!(approx_eq(info.factor, 0.708));
+        assert!(info.inv_peak.is_infinite());
     }
 
     #[test]
@@ -1018,9 +1028,9 @@ mod tests {
             track_gain: Some(-6.0),
             ..Default::default()
         };
-        let factor = compute_replaygain_factor(Some(&rg)).unwrap();
+        let info = compute_replaygain_info(Some(&rg)).unwrap();
         // -6 dB = 10^(-0.3) ≈ 0.501.
-        assert!(approx_eq(factor, 0.501));
+        assert!(approx_eq(info.factor, 0.501));
     }
 
     #[test]
@@ -1029,8 +1039,8 @@ mod tests {
             fallback_gain: Some(-6.0),
             ..Default::default()
         };
-        let factor = compute_replaygain_factor(Some(&rg)).unwrap();
-        assert!(approx_eq(factor, 0.501));
+        let info = compute_replaygain_info(Some(&rg)).unwrap();
+        assert!(approx_eq(info.factor, 0.501));
     }
 
     #[test]
@@ -1040,20 +1050,22 @@ mod tests {
             base_gain: Some(-6.0),
             ..Default::default()
         };
-        let factor = compute_replaygain_factor(Some(&rg)).unwrap();
+        let info = compute_replaygain_info(Some(&rg)).unwrap();
         // -12 dB = 10^(-0.6) ≈ 0.251.
-        assert!(approx_eq(factor, 0.251));
+        assert!(approx_eq(info.factor, 0.251));
     }
 
     #[test]
-    fn replaygain_clamps_to_peak_to_prevent_clipping() {
+    fn replaygain_reports_inv_peak_without_clamping_factor() {
         let rg = ReplayGain {
             album_gain: Some(6.0),
             album_peak: Some(0.9),
             ..Default::default()
         };
-        let factor = compute_replaygain_factor(Some(&rg)).unwrap();
-        // Unclamped 10^(0.3) ≈ 1.995 would clip at peak 0.9; clamped to 1/0.9 ≈ 1.111.
-        assert!(approx_eq(factor, 1.0 / 0.9));
+        let info = compute_replaygain_info(Some(&rg)).unwrap();
+        // Factor is returned unclamped so the playback thread can combine it
+        // with the live preamp before clipping protection kicks in.
+        assert!(approx_eq(info.factor, 10f32.powf(0.3)));
+        assert!(approx_eq(info.inv_peak, 1.0 / 0.9));
     }
 }

--- a/blackbird-core/src/queue.rs
+++ b/blackbird-core/src/queue.rs
@@ -15,33 +15,28 @@ use crate::{
     playback_thread::{LogicToPlaybackMessage, PlaybackThreadSendHandle, TrackPlayback},
 };
 
-/// Convenience that reads the relevant bits of [`AppState`] and computes the
-/// ReplayGain factor for `track_id`, returning `None` if the track is not in
-/// the library or no gain applies.
+/// Convenience that reads the track's ReplayGain metadata from the library
+/// and computes the linear factor. Returns `None` if the track is unknown or
+/// has no usable gain data.
+///
+/// The returned factor is unconditional — whether it is actually applied is
+/// decided inside the playback thread via the shared atomic toggle, so that
+/// flipping the setting affects the currently playing source.
 pub(crate) fn gain_for_track(state: &AppState, track_id: &TrackId) -> Option<f32> {
     let track = state.library.track_map.get(track_id)?;
-    compute_replaygain_factor(state.apply_replaygain, track.replay_gain.as_ref())
+    compute_replaygain_factor(track.replay_gain.as_ref())
 }
 
-/// Computes the linear amplification factor to apply to a track for
-/// ReplayGain, if any.
+/// Computes the linear amplification factor described by `replay_gain`.
 ///
-/// Returns `None` if ReplayGain is disabled, no metadata is available, or no
-/// gain value can be determined.
-///
-/// Prefers album gain over track gain (matching the default of foobar2000,
-/// MPD, and similar players) so that intra-album loudness relationships are
-/// preserved. `baseGain` (if present) is added to the chosen gain, and
-/// `fallbackGain` is used if neither track nor album gain is available. The
-/// resulting linear factor is clamped so that `factor * peak <= 1.0`,
-/// preventing digital clipping.
-pub(crate) fn compute_replaygain_factor(
-    apply_replaygain: bool,
-    replay_gain: Option<&ReplayGain>,
-) -> Option<f32> {
-    if !apply_replaygain {
-        return None;
-    }
+/// Returns `None` if no metadata is present or no gain value can be
+/// determined. Prefers album gain over track gain (matching the default of
+/// foobar2000, MPD, and similar players) so that intra-album loudness
+/// relationships are preserved. `baseGain` (if present) is added to the
+/// chosen gain, and `fallbackGain` is used if neither track nor album gain is
+/// available. The resulting linear factor is clamped so that
+/// `factor * peak <= 1.0`, preventing digital clipping.
+pub(crate) fn compute_replaygain_factor(replay_gain: Option<&ReplayGain>) -> Option<f32> {
     let rg = replay_gain?;
 
     let (gain_db, peak) = match (rg.album_gain, rg.track_gain) {
@@ -1001,17 +996,8 @@ mod tests {
     }
 
     #[test]
-    fn replaygain_disabled_returns_none() {
-        let rg = ReplayGain {
-            track_gain: Some(-6.0),
-            ..Default::default()
-        };
-        assert!(compute_replaygain_factor(false, Some(&rg)).is_none());
-    }
-
-    #[test]
     fn replaygain_missing_metadata_returns_none() {
-        assert!(compute_replaygain_factor(true, None).is_none());
+        assert!(compute_replaygain_factor(None).is_none());
     }
 
     #[test]
@@ -1021,7 +1007,7 @@ mod tests {
             album_gain: Some(-3.0),
             ..Default::default()
         };
-        let factor = compute_replaygain_factor(true, Some(&rg)).unwrap();
+        let factor = compute_replaygain_factor(Some(&rg)).unwrap();
         // -3 dB = 10^(-0.15) ≈ 0.708.
         assert!(approx_eq(factor, 0.708));
     }
@@ -1032,7 +1018,7 @@ mod tests {
             track_gain: Some(-6.0),
             ..Default::default()
         };
-        let factor = compute_replaygain_factor(true, Some(&rg)).unwrap();
+        let factor = compute_replaygain_factor(Some(&rg)).unwrap();
         // -6 dB = 10^(-0.3) ≈ 0.501.
         assert!(approx_eq(factor, 0.501));
     }
@@ -1043,7 +1029,7 @@ mod tests {
             fallback_gain: Some(-6.0),
             ..Default::default()
         };
-        let factor = compute_replaygain_factor(true, Some(&rg)).unwrap();
+        let factor = compute_replaygain_factor(Some(&rg)).unwrap();
         assert!(approx_eq(factor, 0.501));
     }
 
@@ -1054,7 +1040,7 @@ mod tests {
             base_gain: Some(-6.0),
             ..Default::default()
         };
-        let factor = compute_replaygain_factor(true, Some(&rg)).unwrap();
+        let factor = compute_replaygain_factor(Some(&rg)).unwrap();
         // -12 dB = 10^(-0.6) ≈ 0.251.
         assert!(approx_eq(factor, 0.251));
     }
@@ -1066,7 +1052,7 @@ mod tests {
             album_peak: Some(0.9),
             ..Default::default()
         };
-        let factor = compute_replaygain_factor(true, Some(&rg)).unwrap();
+        let factor = compute_replaygain_factor(Some(&rg)).unwrap();
         // Unclamped 10^(0.3) ≈ 1.995 would clip at peak 0.9; clamped to 1/0.9 ≈ 1.111.
         assert!(approx_eq(factor, 1.0 / 0.9));
     }

--- a/blackbird-core/src/queue.rs
+++ b/blackbird-core/src/queue.rs
@@ -12,7 +12,7 @@ use crate::{
     AppState, Logic, PlaybackMode, TrackLoadMode,
     app_state::AppStateError,
     library::Library,
-    playback_thread::{LogicToPlaybackMessage, PlaybackThreadSendHandle},
+    playback_thread::{LogicToPlaybackMessage, PlaybackThreadSendHandle, TrackPlayback},
 };
 
 /// Convenience that reads the relevant bits of [`AppState`] and computes the
@@ -20,11 +20,7 @@ use crate::{
 /// the library or no gain applies.
 pub(crate) fn gain_for_track(state: &AppState, track_id: &TrackId) -> Option<f32> {
     let track = state.library.track_map.get(track_id)?;
-    compute_replaygain_factor(
-        state.apply_replaygain,
-        track.replay_gain.as_ref(),
-        state.playback_mode,
-    )
+    compute_replaygain_factor(state.apply_replaygain, track.replay_gain.as_ref())
 }
 
 /// Computes the linear amplification factor to apply to a track for
@@ -33,31 +29,25 @@ pub(crate) fn gain_for_track(state: &AppState, track_id: &TrackId) -> Option<f32
 /// Returns `None` if ReplayGain is disabled, no metadata is available, or no
 /// gain value can be determined.
 ///
-/// Picks album gain in group modes, falling back to track gain; picks track
-/// gain otherwise, falling back to album gain. `base_gain` (if present) is
-/// added to the chosen gain, and `fallback_gain` is used if neither
-/// track nor album gain is available. The resulting linear factor is clamped
-/// so that `factor * peak <= 1.0`, preventing digital clipping.
+/// Prefers album gain over track gain (matching the default of foobar2000,
+/// MPD, and similar players) so that intra-album loudness relationships are
+/// preserved. `baseGain` (if present) is added to the chosen gain, and
+/// `fallbackGain` is used if neither track nor album gain is available. The
+/// resulting linear factor is clamped so that `factor * peak <= 1.0`,
+/// preventing digital clipping.
 pub(crate) fn compute_replaygain_factor(
     apply_replaygain: bool,
     replay_gain: Option<&ReplayGain>,
-    mode: PlaybackMode,
 ) -> Option<f32> {
     if !apply_replaygain {
         return None;
     }
     let rg = replay_gain?;
 
-    let (primary_gain, primary_peak, secondary_gain, secondary_peak) = if mode.is_group_mode() {
-        (rg.album_gain, rg.album_peak, rg.track_gain, rg.track_peak)
-    } else {
-        (rg.track_gain, rg.track_peak, rg.album_gain, rg.album_peak)
-    };
-
-    let (gain_db, peak) = match (primary_gain, secondary_gain) {
-        (Some(g), _) => (g, primary_peak.or(secondary_peak)),
-        (None, Some(g)) => (g, secondary_peak.or(primary_peak)),
-        (None, None) => (rg.fallback_gain?, primary_peak.or(secondary_peak)),
+    let (gain_db, peak) = match (rg.album_gain, rg.track_gain) {
+        (Some(g), _) => (g, rg.album_peak.or(rg.track_peak)),
+        (None, Some(g)) => (g, rg.track_peak.or(rg.album_peak)),
+        (None, None) => (rg.fallback_gain?, rg.album_peak.or(rg.track_peak)),
     };
 
     let total_db = gain_db + rg.base_gain.unwrap_or(0.0);
@@ -204,17 +194,19 @@ impl Logic {
             let st = self.read_state();
             st.queue.audio_cache.get(track_id).cloned().map(|data| {
                 let gain = gain_for_track(&st, track_id);
-                (data, gain)
+                TrackPlayback {
+                    track_id: track_id.clone(),
+                    data,
+                    gain,
+                }
             })
         };
-        if let Some((data, gain)) = cached {
+        if let Some(track) = cached {
             tracing::debug!("Playing from cache: {}", track_id.0);
-            self.send_to_playback(LogicToPlaybackMessage::LoadTrack(
-                track_id.clone(),
-                data,
-                TrackLoadMode::Play,
-                gain,
-            ));
+            self.send_to_playback(LogicToPlaybackMessage::LoadTrack {
+                track,
+                mode: TrackLoadMode::Play,
+            });
         } else {
             tracing::debug!("Loading track {} (req_id={})", track_id.0, req_id);
             self.load_track_internal(track_id.clone(), req_id, TrackLoadBehavior::Play);
@@ -408,12 +400,14 @@ pub(crate) fn handle_load_response(
                         track_id.0,
                         request_id
                     );
-                    playback_tx.send(LogicToPlaybackMessage::LoadTrack(
-                        track_id.clone(),
-                        data,
-                        TrackLoadMode::Play,
-                        gain,
-                    ));
+                    playback_tx.send(LogicToPlaybackMessage::LoadTrack {
+                        track: TrackPlayback {
+                            track_id: track_id.clone(),
+                            data,
+                            gain,
+                        },
+                        mode: TrackLoadMode::Play,
+                    });
                 }
                 TrackLoadBehavior::Paused(position) if is_current_target => {
                     tracing::debug!(
@@ -421,12 +415,14 @@ pub(crate) fn handle_load_response(
                         track_id.0,
                         request_id
                     );
-                    playback_tx.send(LogicToPlaybackMessage::LoadTrack(
-                        track_id.clone(),
-                        data,
-                        TrackLoadMode::Paused(position),
-                        gain,
-                    ));
+                    playback_tx.send(LogicToPlaybackMessage::LoadTrack {
+                        track: TrackPlayback {
+                            track_id: track_id.clone(),
+                            data,
+                            gain,
+                        },
+                        mode: TrackLoadMode::Paused(position),
+                    });
                 }
                 _ => {
                     tracing::debug!(
@@ -1010,44 +1006,34 @@ mod tests {
             track_gain: Some(-6.0),
             ..Default::default()
         };
-        assert!(compute_replaygain_factor(false, Some(&rg), PlaybackMode::Sequential).is_none());
+        assert!(compute_replaygain_factor(false, Some(&rg)).is_none());
     }
 
     #[test]
     fn replaygain_missing_metadata_returns_none() {
-        assert!(compute_replaygain_factor(true, None, PlaybackMode::Sequential).is_none());
+        assert!(compute_replaygain_factor(true, None).is_none());
     }
 
     #[test]
-    fn replaygain_track_mode_uses_track_gain() {
+    fn replaygain_prefers_album_gain_over_track_gain() {
         let rg = ReplayGain {
             track_gain: Some(-6.0),
             album_gain: Some(-3.0),
             ..Default::default()
         };
-        let factor = compute_replaygain_factor(true, Some(&rg), PlaybackMode::Sequential).unwrap();
-        assert!(approx_eq(factor, 0.501));
-    }
-
-    #[test]
-    fn replaygain_group_mode_uses_album_gain() {
-        let rg = ReplayGain {
-            track_gain: Some(-6.0),
-            album_gain: Some(-3.0),
-            ..Default::default()
-        };
-        let factor =
-            compute_replaygain_factor(true, Some(&rg), PlaybackMode::GroupShuffle).unwrap();
+        let factor = compute_replaygain_factor(true, Some(&rg)).unwrap();
+        // -3 dB = 10^(-0.15) ≈ 0.708.
         assert!(approx_eq(factor, 0.708));
     }
 
     #[test]
-    fn replaygain_falls_back_across_track_and_album() {
+    fn replaygain_falls_back_to_track_gain_when_no_album_gain() {
         let rg = ReplayGain {
-            album_gain: Some(-6.0),
+            track_gain: Some(-6.0),
             ..Default::default()
         };
-        let factor = compute_replaygain_factor(true, Some(&rg), PlaybackMode::Sequential).unwrap();
+        let factor = compute_replaygain_factor(true, Some(&rg)).unwrap();
+        // -6 dB = 10^(-0.3) ≈ 0.501.
         assert!(approx_eq(factor, 0.501));
     }
 
@@ -1057,18 +1043,18 @@ mod tests {
             fallback_gain: Some(-6.0),
             ..Default::default()
         };
-        let factor = compute_replaygain_factor(true, Some(&rg), PlaybackMode::Sequential).unwrap();
+        let factor = compute_replaygain_factor(true, Some(&rg)).unwrap();
         assert!(approx_eq(factor, 0.501));
     }
 
     #[test]
     fn replaygain_adds_base_gain() {
         let rg = ReplayGain {
-            track_gain: Some(-6.0),
+            album_gain: Some(-6.0),
             base_gain: Some(-6.0),
             ..Default::default()
         };
-        let factor = compute_replaygain_factor(true, Some(&rg), PlaybackMode::Sequential).unwrap();
+        let factor = compute_replaygain_factor(true, Some(&rg)).unwrap();
         // -12 dB = 10^(-0.6) ≈ 0.251.
         assert!(approx_eq(factor, 0.251));
     }
@@ -1076,11 +1062,11 @@ mod tests {
     #[test]
     fn replaygain_clamps_to_peak_to_prevent_clipping() {
         let rg = ReplayGain {
-            track_gain: Some(6.0),
-            track_peak: Some(0.9),
+            album_gain: Some(6.0),
+            album_peak: Some(0.9),
             ..Default::default()
         };
-        let factor = compute_replaygain_factor(true, Some(&rg), PlaybackMode::Sequential).unwrap();
+        let factor = compute_replaygain_factor(true, Some(&rg)).unwrap();
         // Unclamped 10^(0.3) ≈ 1.995 would clip at peak 0.9; clamped to 1/0.9 ≈ 1.111.
         assert!(approx_eq(factor, 1.0 / 0.9));
     }

--- a/blackbird-core/src/queue.rs
+++ b/blackbird-core/src/queue.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use blackbird_state::TrackId;
-use blackbird_subsonic::ClientResult;
+use blackbird_subsonic::{ClientResult, ReplayGain};
 
 use crate::{
     AppState, Logic, PlaybackMode, TrackLoadMode,
@@ -14,6 +14,63 @@ use crate::{
     library::Library,
     playback_thread::{LogicToPlaybackMessage, PlaybackThreadSendHandle},
 };
+
+/// Convenience that reads the relevant bits of [`AppState`] and computes the
+/// ReplayGain factor for `track_id`, returning `None` if the track is not in
+/// the library or no gain applies.
+pub(crate) fn gain_for_track(state: &AppState, track_id: &TrackId) -> Option<f32> {
+    let track = state.library.track_map.get(track_id)?;
+    compute_replaygain_factor(
+        state.apply_replaygain,
+        track.replay_gain.as_ref(),
+        state.playback_mode,
+    )
+}
+
+/// Computes the linear amplification factor to apply to a track for
+/// ReplayGain, if any.
+///
+/// Returns `None` if ReplayGain is disabled, no metadata is available, or no
+/// gain value can be determined.
+///
+/// Picks album gain in group modes, falling back to track gain; picks track
+/// gain otherwise, falling back to album gain. `base_gain` (if present) is
+/// added to the chosen gain, and `fallback_gain` is used if neither
+/// track nor album gain is available. The resulting linear factor is clamped
+/// so that `factor * peak <= 1.0`, preventing digital clipping.
+pub(crate) fn compute_replaygain_factor(
+    apply_replaygain: bool,
+    replay_gain: Option<&ReplayGain>,
+    mode: PlaybackMode,
+) -> Option<f32> {
+    if !apply_replaygain {
+        return None;
+    }
+    let rg = replay_gain?;
+
+    let (primary_gain, primary_peak, secondary_gain, secondary_peak) = if mode.is_group_mode() {
+        (rg.album_gain, rg.album_peak, rg.track_gain, rg.track_peak)
+    } else {
+        (rg.track_gain, rg.track_peak, rg.album_gain, rg.album_peak)
+    };
+
+    let (gain_db, peak) = match (primary_gain, secondary_gain) {
+        (Some(g), _) => (g, primary_peak.or(secondary_peak)),
+        (None, Some(g)) => (g, secondary_peak.or(primary_peak)),
+        (None, None) => (rg.fallback_gain?, primary_peak.or(secondary_peak)),
+    };
+
+    let total_db = gain_db + rg.base_gain.unwrap_or(0.0);
+    let factor = 10f32.powf(total_db / 20.0);
+
+    // Prevent clipping: scale down so the loudest sample stays at or below 1.0.
+    let clipping_ceiling = peak
+        .filter(|p| *p > 0.0)
+        .map(|p| 1.0 / p)
+        .unwrap_or(f32::INFINITY);
+
+    Some(factor.min(clipping_ceiling))
+}
 
 /// How a loaded track should be handled after streaming.
 pub(crate) enum TrackLoadBehavior {
@@ -143,13 +200,20 @@ impl Logic {
         };
 
         // If already cached, play immediately.
-        let cached_track = self.read_state().queue.audio_cache.get(track_id).cloned();
-        if let Some(data) = cached_track {
+        let cached = {
+            let st = self.read_state();
+            st.queue.audio_cache.get(track_id).cloned().map(|data| {
+                let gain = gain_for_track(&st, track_id);
+                (data, gain)
+            })
+        };
+        if let Some((data, gain)) = cached {
             tracing::debug!("Playing from cache: {}", track_id.0);
             self.send_to_playback(LogicToPlaybackMessage::LoadTrack(
                 track_id.clone(),
                 data,
                 TrackLoadMode::Play,
+                gain,
             ));
         } else {
             tracing::debug!("Loading track {} (req_id={})", track_id.0, req_id);
@@ -329,14 +393,13 @@ pub(crate) fn handle_load_response(
 ) {
     match response {
         Ok(data) => {
-            let is_current_target =
-                state.read().unwrap().queue.current_target.as_ref() == Some(&track_id);
-            state
-                .write()
-                .unwrap()
-                .queue
-                .audio_cache
-                .insert(track_id.clone(), data.clone());
+            let (is_current_target, gain) = {
+                let mut st = state.write().unwrap();
+                st.queue.audio_cache.insert(track_id.clone(), data.clone());
+                let is_current = st.queue.current_target.as_ref() == Some(&track_id);
+                let gain = gain_for_track(&st, &track_id);
+                (is_current, gain)
+            };
 
             match behavior {
                 TrackLoadBehavior::Play if is_current_target => {
@@ -349,6 +412,7 @@ pub(crate) fn handle_load_response(
                         track_id.clone(),
                         data,
                         TrackLoadMode::Play,
+                        gain,
                     ));
                 }
                 TrackLoadBehavior::Paused(position) if is_current_target => {
@@ -361,6 +425,7 @@ pub(crate) fn handle_load_response(
                         track_id.clone(),
                         data,
                         TrackLoadMode::Paused(position),
+                        gain,
                     ));
                 }
                 _ => {
@@ -647,6 +712,7 @@ mod tests {
             starred: idx.is_multiple_of(3), // every 3rd track is starred
             play_count: None,
             album_id: None,
+            replay_gain: None,
         }
     }
 
@@ -932,5 +998,90 @@ mod tests {
         let queue = make_queue();
         let window = compute_window_from_queue(&queue, 2);
         assert!(window.is_empty());
+    }
+
+    fn approx_eq(a: f32, b: f32) -> bool {
+        (a - b).abs() < 1e-3
+    }
+
+    #[test]
+    fn replaygain_disabled_returns_none() {
+        let rg = ReplayGain {
+            track_gain: Some(-6.0),
+            ..Default::default()
+        };
+        assert!(compute_replaygain_factor(false, Some(&rg), PlaybackMode::Sequential).is_none());
+    }
+
+    #[test]
+    fn replaygain_missing_metadata_returns_none() {
+        assert!(compute_replaygain_factor(true, None, PlaybackMode::Sequential).is_none());
+    }
+
+    #[test]
+    fn replaygain_track_mode_uses_track_gain() {
+        let rg = ReplayGain {
+            track_gain: Some(-6.0),
+            album_gain: Some(-3.0),
+            ..Default::default()
+        };
+        let factor = compute_replaygain_factor(true, Some(&rg), PlaybackMode::Sequential).unwrap();
+        assert!(approx_eq(factor, 0.501));
+    }
+
+    #[test]
+    fn replaygain_group_mode_uses_album_gain() {
+        let rg = ReplayGain {
+            track_gain: Some(-6.0),
+            album_gain: Some(-3.0),
+            ..Default::default()
+        };
+        let factor =
+            compute_replaygain_factor(true, Some(&rg), PlaybackMode::GroupShuffle).unwrap();
+        assert!(approx_eq(factor, 0.708));
+    }
+
+    #[test]
+    fn replaygain_falls_back_across_track_and_album() {
+        let rg = ReplayGain {
+            album_gain: Some(-6.0),
+            ..Default::default()
+        };
+        let factor = compute_replaygain_factor(true, Some(&rg), PlaybackMode::Sequential).unwrap();
+        assert!(approx_eq(factor, 0.501));
+    }
+
+    #[test]
+    fn replaygain_uses_fallback_gain_when_no_track_or_album() {
+        let rg = ReplayGain {
+            fallback_gain: Some(-6.0),
+            ..Default::default()
+        };
+        let factor = compute_replaygain_factor(true, Some(&rg), PlaybackMode::Sequential).unwrap();
+        assert!(approx_eq(factor, 0.501));
+    }
+
+    #[test]
+    fn replaygain_adds_base_gain() {
+        let rg = ReplayGain {
+            track_gain: Some(-6.0),
+            base_gain: Some(-6.0),
+            ..Default::default()
+        };
+        let factor = compute_replaygain_factor(true, Some(&rg), PlaybackMode::Sequential).unwrap();
+        // -12 dB = 10^(-0.6) ≈ 0.251.
+        assert!(approx_eq(factor, 0.251));
+    }
+
+    #[test]
+    fn replaygain_clamps_to_peak_to_prevent_clipping() {
+        let rg = ReplayGain {
+            track_gain: Some(6.0),
+            track_peak: Some(0.9),
+            ..Default::default()
+        };
+        let factor = compute_replaygain_factor(true, Some(&rg), PlaybackMode::Sequential).unwrap();
+        // Unclamped 10^(0.3) ≈ 1.995 would clip at peak 0.9; clamped to 1/0.9 ≈ 1.111.
+        assert!(approx_eq(factor, 1.0 / 0.9));
     }
 }

--- a/blackbird-state/src/track.rs
+++ b/blackbird-state/src/track.rs
@@ -37,6 +37,8 @@ pub struct Track {
     pub starred: bool,
     /// The number of times this track has been played
     pub play_count: Option<u64>,
+    /// ReplayGain metadata, if provided by the server.
+    pub replay_gain: Option<bs::ReplayGain>,
 }
 impl From<bs::Child> for Track {
     fn from(child: bs::Child) -> Self {
@@ -55,6 +57,7 @@ impl From<bs::Child> for Track {
             album_id: child.album_id.map(|id| AlbumId(id.into())),
             starred: child.starred.is_some(),
             play_count: child.play_count,
+            replay_gain: child.replay_gain,
         }
     }
 }

--- a/blackbird-subsonic/src/song.rs
+++ b/blackbird-subsonic/src/song.rs
@@ -2,6 +2,32 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Client, ClientResult};
 
+/// Per-track ReplayGain metadata, as returned by OpenSubsonic-compatible
+/// servers. All fields are optional because servers may return any subset.
+/// Gains are in decibels; peaks are sample magnitudes in the range `[0.0, 1.0+]`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplayGain {
+    /// Track-level gain adjustment, in dB.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub track_gain: Option<f32>,
+    /// Album-level gain adjustment, in dB.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub album_gain: Option<f32>,
+    /// Peak sample magnitude for the track.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub track_peak: Option<f32>,
+    /// Peak sample magnitude for the album.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub album_peak: Option<f32>,
+    /// Server-side base gain to apply on top of track/album gain, in dB.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_gain: Option<f32>,
+    /// Gain to use when neither track nor album gain is available, in dB.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_gain: Option<f32>,
+}
+
 /// Represents a child item (file or directory) in the Subsonic API
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -96,6 +122,9 @@ pub struct Child {
     /// The original height of the media
     #[serde(skip_serializing_if = "Option::is_none")]
     pub original_height: Option<u32>,
+    /// ReplayGain metadata (OpenSubsonic extension).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replay_gain: Option<ReplayGain>,
 }
 
 impl Client {

--- a/blackbird-tui/src/app.rs
+++ b/blackbird-tui/src/app.rs
@@ -112,6 +112,10 @@ impl App {
 
     pub fn tick(&mut self) {
         self.tick_count = self.tick_count.wrapping_add(1);
+        // Keep ReplayGain application in sync with the config; cheap since it
+        // is only used when loading the next track.
+        self.logic
+            .set_apply_replaygain(self.config.playback.apply_replaygain);
         self.logic.update();
         self.cover_art_cache.update();
         self.cover_art_cache

--- a/blackbird-tui/src/app.rs
+++ b/blackbird-tui/src/app.rs
@@ -112,10 +112,12 @@ impl App {
 
     pub fn tick(&mut self) {
         self.tick_count = self.tick_count.wrapping_add(1);
-        // Keep ReplayGain application in sync with the config. Cheap:
-        // `set_apply_replaygain` is a no-op when the value is unchanged.
+        // Keep ReplayGain settings in sync with the config. Cheap: the
+        // setters are no-ops when the value is unchanged.
         self.logic
             .set_apply_replaygain(self.config.playback.apply_replaygain);
+        self.logic
+            .set_replaygain_preamp_db(self.config.playback.replaygain_preamp_db);
         self.logic.update();
         self.cover_art_cache.update();
         self.cover_art_cache

--- a/blackbird-tui/src/app.rs
+++ b/blackbird-tui/src/app.rs
@@ -112,8 +112,8 @@ impl App {
 
     pub fn tick(&mut self) {
         self.tick_count = self.tick_count.wrapping_add(1);
-        // Keep ReplayGain application in sync with the config; cheap since it
-        // is only used when loading the next track.
+        // Keep ReplayGain application in sync with the config. Cheap:
+        // `set_apply_replaygain` is a no-op when the value is unchanged.
         self.logic
             .set_apply_replaygain(self.config.playback.apply_replaygain);
         self.logic.update();

--- a/blackbird-tui/src/config.rs
+++ b/blackbird-tui/src/config.rs
@@ -23,6 +23,9 @@ pub struct Config {
     /// Last playback state, persisted across sessions.
     #[serde(default)]
     pub last_playback: blackbird_client_shared::config::LastPlayback,
+    /// Playback-related settings shared across clients.
+    #[serde(default)]
+    pub playback: blackbird_client_shared::config::Playback,
     /// Catch-all for unknown top-level sections (e.g. keybindings from GUI).
     #[serde(flatten)]
     pub extra: toml::Table,

--- a/blackbird-tui/src/main.rs
+++ b/blackbird-tui/src/main.rs
@@ -61,6 +61,7 @@ fn main() -> anyhow::Result<()> {
         transcode: config.server.transcode,
         volume: config.general.volume,
         apply_replaygain: config.playback.apply_replaygain,
+        replaygain_preamp_db: config.playback.replaygain_preamp_db,
         sort_order: config.last_playback.sort_order,
         playback_mode: config.last_playback.playback_mode,
         last_playback: config.last_playback.as_track_and_position(),

--- a/blackbird-tui/src/main.rs
+++ b/blackbird-tui/src/main.rs
@@ -60,6 +60,7 @@ fn main() -> anyhow::Result<()> {
         password: config.server.password.clone(),
         transcode: config.server.transcode,
         volume: config.general.volume,
+        apply_replaygain: config.playback.apply_replaygain,
         sort_order: config.last_playback.sort_order,
         playback_mode: config.last_playback.playback_mode,
         last_playback: config.last_playback.as_track_and_position(),

--- a/blackbird-tui/src/ui/settings.rs
+++ b/blackbird-tui/src/ui/settings.rs
@@ -242,6 +242,15 @@ fn build_rows() -> Vec<SettingsRow> {
             set: |c, v| c.playback.apply_replaygain = v,
             default: || Playback::default().apply_replaygain,
         },
+        SettingsRow::F32Field {
+            label: "ReplayGain preamp (dB)",
+            section: Section::Playback,
+            get: |c| c.playback.replaygain_preamp_db,
+            set: |c, v| c.playback.replaygain_preamp_db = v,
+            default: || Playback::default().replaygain_preamp_db,
+            min: -12.0,
+            max: 12.0,
+        },
         // Colors section.
         SettingsRow::SectionSpacer,
         SettingsRow::SectionHeader("Colors"),

--- a/blackbird-tui/src/ui/settings.rs
+++ b/blackbird-tui/src/ui/settings.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::LazyLock};
 
 use blackbird_client_shared::{
-    config::{AlbumArtStyle, Layout},
+    config::{AlbumArtStyle, Layout, Playback},
     style as shared_style,
 };
 use blackbird_core::blackbird_state::{AlbumId, CoverArtId, TrackId};
@@ -101,6 +101,7 @@ enum SettingsRow {
 enum Section {
     Server,
     Layout,
+    Playback,
     Colors,
     General,
 }
@@ -230,6 +231,16 @@ fn build_rows() -> Vec<SettingsRow> {
             get: |c| c.layout.use_terminal_background,
             set: |c, v| c.layout.use_terminal_background = v,
             default: || crate::config::Layout::default().use_terminal_background,
+        },
+        // Playback section.
+        SettingsRow::SectionSpacer,
+        SettingsRow::SectionHeader("Playback"),
+        SettingsRow::BoolField {
+            label: "Apply ReplayGain",
+            section: Section::Playback,
+            get: |c| c.playback.apply_replaygain,
+            set: |c, v| c.playback.apply_replaygain = v,
+            default: || Playback::default().apply_replaygain,
         },
         // Colors section.
         SettingsRow::SectionSpacer,
@@ -994,6 +1005,9 @@ pub fn handle_key(
                     }
                     Section::Layout => {
                         config.layout = crate::config::Layout::default();
+                    }
+                    Section::Playback => {
+                        config.playback = Playback::default();
                     }
                     Section::Colors => {
                         config.style = shared_style::Style::default();

--- a/blackbird/src/main.rs
+++ b/blackbird/src/main.rs
@@ -54,6 +54,7 @@ fn main() {
         password: config.shared.server.password.clone(),
         transcode: config.shared.server.transcode,
         volume: config.general.volume,
+        apply_replaygain: config.shared.playback.apply_replaygain,
         sort_order: config.shared.last_playback.sort_order,
         playback_mode: config.shared.last_playback.playback_mode,
         last_playback: config.shared.last_playback.as_track_and_position(),
@@ -320,6 +321,10 @@ impl eframe::App for App {
 
         #[cfg(feature = "media-controls")]
         self.controls.update();
+        // Keep ReplayGain application in sync with the config; cheap since it
+        // is only used when loading the next track.
+        self.logic
+            .set_apply_replaygain(self.config.read().unwrap().shared.playback.apply_replaygain);
         self.logic.update();
         self.cover_art_cache.update(ctx);
         // Preload album art for tracks surrounding the next track in queue

--- a/blackbird/src/main.rs
+++ b/blackbird/src/main.rs
@@ -55,6 +55,7 @@ fn main() {
         transcode: config.shared.server.transcode,
         volume: config.general.volume,
         apply_replaygain: config.shared.playback.apply_replaygain,
+        replaygain_preamp_db: config.shared.playback.replaygain_preamp_db,
         sort_order: config.shared.last_playback.sort_order,
         playback_mode: config.shared.last_playback.playback_mode,
         last_playback: config.shared.last_playback.as_track_and_position(),
@@ -321,10 +322,15 @@ impl eframe::App for App {
 
         #[cfg(feature = "media-controls")]
         self.controls.update();
-        // Keep ReplayGain application in sync with the config. Cheap:
-        // `set_apply_replaygain` is a no-op when the value is unchanged.
-        self.logic
-            .set_apply_replaygain(self.config.read().unwrap().shared.playback.apply_replaygain);
+        // Keep ReplayGain settings in sync with the config. Cheap: the
+        // setters are no-ops when the value is unchanged.
+        {
+            let cfg = self.config.read().unwrap();
+            self.logic
+                .set_apply_replaygain(cfg.shared.playback.apply_replaygain);
+            self.logic
+                .set_replaygain_preamp_db(cfg.shared.playback.replaygain_preamp_db);
+        }
         self.logic.update();
         self.cover_art_cache.update(ctx);
         // Preload album art for tracks surrounding the next track in queue

--- a/blackbird/src/main.rs
+++ b/blackbird/src/main.rs
@@ -321,8 +321,8 @@ impl eframe::App for App {
 
         #[cfg(feature = "media-controls")]
         self.controls.update();
-        // Keep ReplayGain application in sync with the config; cheap since it
-        // is only used when loading the next track.
+        // Keep ReplayGain application in sync with the config. Cheap:
+        // `set_apply_replaygain` is a no-op when the value is unchanged.
         self.logic
             .set_apply_replaygain(self.config.read().unwrap().shared.playback.apply_replaygain);
         self.logic.update();

--- a/blackbird/src/ui/settings.rs
+++ b/blackbird/src/ui/settings.rs
@@ -105,6 +105,26 @@ pub fn ui(ctx: &Context, config: &mut Config, settings: &mut SettingsState) -> b
                         });
                     });
 
+                    // ── Playback ────────────────────────────────────
+                    let playback_default = blackbird_client_shared::config::Playback::default();
+                    section(ui, "Playback", |ui| {
+                        changed |= bool_row(
+                            ui,
+                            "Apply ReplayGain",
+                            &mut config.shared.playback.apply_replaygain,
+                            &playback_default.apply_replaygain,
+                        );
+
+                        reset_section_button(
+                            ui,
+                            config.shared.playback != playback_default,
+                            || {
+                                config.shared.playback = playback_default;
+                                changed = true;
+                            },
+                        );
+                    });
+
                     // ── Colors ──────────────────────────────────────
                     let style_default = shared_style::Style::default();
                     CollapsingHeader::new(RichText::new("Colors").heading())

--- a/blackbird/src/ui/settings.rs
+++ b/blackbird/src/ui/settings.rs
@@ -114,6 +114,15 @@ pub fn ui(ctx: &Context, config: &mut Config, settings: &mut SettingsState) -> b
                             &mut config.shared.playback.apply_replaygain,
                             &playback_default.apply_replaygain,
                         );
+                        changed |= f32_row(
+                            ui,
+                            "ReplayGain preamp (dB)",
+                            &mut config.shared.playback.replaygain_preamp_db,
+                            &playback_default.replaygain_preamp_db,
+                            -12.0,
+                            12.0,
+                            0.5,
+                        );
 
                         reset_section_button(
                             ui,


### PR DESCRIPTION
## Summary
This PR adds support for ReplayGain metadata to normalize audio playback volume across tracks and albums. ReplayGain adjustments are computed at track load time and applied as linear amplification factors to prevent digital clipping.

## Key Changes

- **ReplayGain metadata structure** (`blackbird-subsonic`): Added `ReplayGain` struct to represent per-track gain metadata from OpenSubsonic-compatible servers, including track/album gain, peak values, base gain, and fallback gain.

- **ReplayGain computation** (`blackbird-core`): Implemented `compute_replaygain_factor()` function that:
  - Selects album gain in group playback modes, track gain otherwise (with fallback)
  - Converts dB values to linear amplification factors
  - Clamps factors to prevent clipping based on peak sample magnitudes
  - Includes comprehensive unit tests covering all gain selection paths

- **Track loading integration**: Modified track loading in `Logic` to compute and pass ReplayGain factors to the playback thread for both cached and newly-loaded tracks.

- **Playback thread integration** (`playback_thread.rs`): Updated `LogicToPlaybackMessage` variants to carry optional gain factors, applying them via `rodio::Source::amplify()` when appending decoded audio to the sink.

- **Configuration**: Added `Playback` config struct with `apply_replaygain` boolean (default: true) to both shared and client-specific configs, with UI controls in both GUI and TUI.

- **State management**: Added `apply_replaygain` field to `AppState` and `LogicArgs`, with getter/setter methods to allow runtime toggling.

- **Track model**: Extended `Track` struct to store optional `ReplayGain` metadata from server responses.

## Implementation Details

- ReplayGain is applied at track load time, not during playback, so changes to the setting only affect subsequently-loaded tracks.
- The gain computation respects playback mode: group modes (shuffle, group shuffle) prefer album gain while sequential modes prefer track gain.
- Peak-based clipping prevention ensures the loudest sample stays at or below 1.0 after amplification.
- All gain values are in decibels and converted to linear factors using the standard formula: `10^(dB/20)`.

https://claude.ai/code/session_01Sd3hBHJ5ETQjUJ1CDMijL8